### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Venafi
 
-Publisher: Splunk \
-Connector Version: 2.1.2 \
-Product Vendor: Venafi \
-Product Name: Venafi \
+Publisher: Splunk <br>
+Connector Version: 2.1.2 <br>
+Product Vendor: Venafi <br>
+Product Name: Venafi <br>
 Minimum Product Version: 6.1.1
 
 This app integrates with an instance of Venafi to perform generic and investigative actions
@@ -21,19 +21,19 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[list policies](#action-list-policies) - Returns a list of all policies in Venafi \
-[create certificate](#action-create-certificate) - Enrolls a certificate in Venafi \
-[list certificates](#action-list-certificates) - Returns a list of certificates in Venafi \
-[renew certificate](#action-renew-certificate) - Requests immediate renewal for an existing certificate in Venafi \
-[revoke certificate](#action-revoke-certificate) - Requests to revoke an existing certificate in Venafi \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[list policies](#action-list-policies) - Returns a list of all policies in Venafi <br>
+[create certificate](#action-create-certificate) - Enrolls a certificate in Venafi <br>
+[list certificates](#action-list-certificates) - Returns a list of certificates in Venafi <br>
+[renew certificate](#action-renew-certificate) - Requests immediate renewal for an existing certificate in Venafi <br>
+[revoke certificate](#action-revoke-certificate) - Requests to revoke an existing certificate in Venafi <br>
 [get certificate](#action-get-certificate) - Downloads specified certificate to the vault
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -48,7 +48,7 @@ No Output
 
 Returns a list of all policies in Venafi
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -77,7 +77,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Enrolls a certificate in Venafi
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 Either Subject or ObjectName parameter must be filled out.
@@ -149,7 +149,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Returns a list of certificates in Venafi
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 Returns certificate details and the total number of certificates that match specified search filters.
@@ -236,7 +236,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Requests immediate renewal for an existing certificate in Venafi
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 A renewable certificate cannot be currently processing, in error, or contain a 'Monitoring' Management Type.
@@ -267,7 +267,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Requests to revoke an existing certificate in Venafi
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 The caller must have write permissions to the certificate object and either the CertificateDN or the Thumbprint parameter must be provided.
@@ -305,7 +305,7 @@ summary.total_objects_successful | numeric | | 0 |
 
 Downloads specified certificate to the vault
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
 * Remove beautifulsoup4 from requirements.txt
+* Update Python version for 3.13

--- a/venafi.json
+++ b/venafi.json
@@ -1520,5 +1520,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/venafi.json
+++ b/venafi.json
@@ -16,7 +16,7 @@
     "main_module": "venafi_connector.py",
     "min_phantom_version": "6.1.1",
     "app_wizard_version": "1.0.0",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_version": [
         "Trust Protection Platform version 21.1, Tested on 24th July 2023"


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)