### PR TITLE
fix: harden Venafi certificate handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.8
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.40.8
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.4
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -331,8 +331,6 @@ action_result.parameter.format | string | | Base64 |
 action_result.parameter.friendly_name | string | | tpp.exampledemo.com |
 action_result.parameter.include_chain | boolean | | True False |
 action_result.parameter.include_private_key | boolean | | True False |
-action_result.parameter.keystore_password | password | | |
-action_result.parameter.password | password | | |
 action_result.parameter.root_first_order | boolean | | True False |
 action_result.data.\*.name | string | | pge.com.cer |
 action_result.data.\*.size | numeric | | 2074 |
@@ -341,6 +339,8 @@ action_result.summary.status | string | | Successfully retrieved certificate and
 action_result.message | string | | Status: Successfully retrieved certificate and downloaded it to vault |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.keystore_password | password | | |
+action_result.parameter.password | password | | |
 
 ______________________________________________________________________
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Report an error when Venafi does not confirm certificate enrollment.
 * Reject unsuccessful certificate downloads before adding them to the SOAR vault.
 * Report an error when Venafi does not confirm certificate renewal or revocation.
+* Keep certificate-export passwords out of action results.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Report an error when Venafi does not confirm certificate enrollment.
 * Reject unsuccessful certificate downloads before adding them to the SOAR vault.
+* Report an error when Venafi does not confirm certificate renewal or revocation.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,5 +1,6 @@
 **Unreleased**
 
+* Stream certificate downloads to the vault with a bounded maximum size.
 * Report an error when Venafi does not confirm certificate enrollment.
 * Reject unsuccessful certificate downloads before adding them to the SOAR vault.
 * Report an error when Venafi does not confirm certificate renewal or revocation.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Report an error when Venafi does not confirm certificate enrollment.
+* Reject unsuccessful certificate downloads before adding them to the SOAR vault.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Report an error when Venafi does not confirm certificate enrollment.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,6 +1,6 @@
 **Unreleased**
 
-* Stream certificate downloads to the vault with a bounded maximum size.
+* Stream certificate downloads to a temporary file before adding them to the SOAR vault.
 * Report an error when Venafi does not confirm certificate enrollment.
 * Reject unsuccessful certificate downloads before adding them to the SOAR vault.
 * Report an error when Venafi does not confirm certificate renewal or revocation.

--- a/venafi.json
+++ b/venafi.json
@@ -1440,14 +1440,6 @@
                     ]
                 },
                 {
-                    "data_path": "action_result.parameter.keystore_password",
-                    "data_type": "password"
-                },
-                {
-                    "data_path": "action_result.parameter.password",
-                    "data_type": "password"
-                },
-                {
                     "data_path": "action_result.parameter.root_first_order",
                     "data_type": "boolean",
                     "example_values": [
@@ -1513,6 +1505,14 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.keystore_password",
+                    "data_type": "password"
+                },
+                {
+                    "data_path": "action_result.parameter.password",
+                    "data_type": "password"
                 }
             ],
             "render": {

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -399,15 +399,6 @@ class VenafiConnector(BaseConnector):
             if not 200 <= r.status_code < 300:
                 return RetVal(action_result.set_status(phantom.APP_ERROR, f"Certificate download failed. Status Code: {r.status_code}"))
 
-            content_length = r.headers.get("Content-Length")
-            if content_length is not None:
-                try:
-                    content_length = int(content_length)
-                except ValueError:
-                    return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download has an invalid Content-Length"))
-                if content_length < 0 or content_length > consts.VENAFI_MAX_CERTIFICATE_DOWNLOAD_SIZE:
-                    return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download exceeds the maximum allowed size"))
-
             content_disposition = r.headers.get("Content-Disposition", "")
             file_name = content_disposition.split('"')[1] if '"' in content_disposition else "certificate"
 
@@ -419,14 +410,10 @@ class VenafiConnector(BaseConnector):
                     if not chunk:
                         continue
                     bytes_written += len(chunk)
-                    if bytes_written > consts.VENAFI_MAX_CERTIFICATE_DOWNLOAD_SIZE:
-                        return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download exceeds the maximum allowed size"))
                     f.write(chunk)
 
             if not bytes_written:
                 return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download is empty"))
-            if content_length is not None and bytes_written != content_length:
-                return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download does not match Content-Length"))
 
             success, msg, vault_id = ph_rules.vault_add(
                 container=self.get_container_id(),
@@ -435,7 +422,7 @@ class VenafiConnector(BaseConnector):
             )
 
             if not success:
-                return RetVal(action_result.set_status(phantom.APP_ERROR, f"Error adding file to the vault, Error: {msg}"))
+                return RetVal(action_result.set_status(phantom.APP_ERROR, f"Certificate download was rejected by the SOAR vault: {msg}"))
 
             vault_info = self._get_vault_info(vault_id)
             if not vault_info:

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -644,7 +644,9 @@ class VenafiConnector(BaseConnector):
     def _handle_get_certificate(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(
+            ActionResult({key: value for key, value in param.items() if key not in {"keystore_password", "password"}})
+        )
         uri = consts.VENAFI_GET_CERTIFICATE_URI
 
         # Optional Certificate filter attributes

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -388,48 +388,72 @@ class VenafiConnector(BaseConnector):
         kwargs["headers"] = {"Content-Type": "application/json", "Authorization": f"Bearer {self._access_token}"}
 
         url = f"{self._base_url}{endpoint}"
+        r = None
+        tmp_file_path = None
         try:
-            r = requests.get(url, timeout=consts.VENAFI_DEFAULT_TIMEOUT, **kwargs)
+            r = requests.get(url, stream=True, timeout=consts.VENAFI_DEFAULT_TIMEOUT, **kwargs)
+
+            if r.status_code == 401:
+                return phantom.APP_ERROR, r.status_code
+
+            if not 200 <= r.status_code < 300:
+                return RetVal(action_result.set_status(phantom.APP_ERROR, f"Certificate download failed. Status Code: {r.status_code}"))
+
+            content_length = r.headers.get("Content-Length")
+            if content_length is not None:
+                try:
+                    content_length = int(content_length)
+                except ValueError:
+                    return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download has an invalid Content-Length"))
+                if content_length < 0 or content_length > consts.VENAFI_MAX_CERTIFICATE_DOWNLOAD_SIZE:
+                    return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download exceeds the maximum allowed size"))
+
+            content_disposition = r.headers.get("Content-Disposition", "")
+            file_name = content_disposition.split('"')[1] if '"' in content_disposition else "certificate"
+
+            fd, tmp_file_path = tempfile.mkstemp(dir=Vault.get_vault_tmp_dir())
+            os.close(fd)
+            bytes_written = 0
+            with open(tmp_file_path, "wb") as f:
+                for chunk in r.iter_content(chunk_size=consts.VENAFI_DOWNLOAD_CHUNK_SIZE):
+                    if not chunk:
+                        continue
+                    bytes_written += len(chunk)
+                    if bytes_written > consts.VENAFI_MAX_CERTIFICATE_DOWNLOAD_SIZE:
+                        return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download exceeds the maximum allowed size"))
+                    f.write(chunk)
+
+            if not bytes_written:
+                return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download is empty"))
+            if content_length is not None and bytes_written != content_length:
+                return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download does not match Content-Length"))
+
+            success, msg, vault_id = ph_rules.vault_add(
+                container=self.get_container_id(),
+                file_location=tmp_file_path,
+                file_name=file_name,
+            )
+
+            if not success:
+                return RetVal(action_result.set_status(phantom.APP_ERROR, f"Error adding file to the vault, Error: {msg}"))
+
+            vault_info = self._get_vault_info(vault_id)
+            if not vault_info:
+                return RetVal(action_result.set_status(phantom.APP_ERROR, f"Failed to find vault entry {vault_id}"))
+
+            action_result.add_data(
+                {phantom.APP_JSON_VAULT_ID: vault_id, phantom.APP_JSON_NAME: file_name, phantom.APP_JSON_SIZE: vault_info["size"]}
+            )
+            self.debug_print("Successfully added file to the vault")
+            return RetVal(action_result.set_status(phantom.APP_SUCCESS))
         except Exception as ex:
             error_message = self._get_error_message_from_exception(ex)
             return RetVal(action_result.set_status(phantom.APP_ERROR, f"{error_message}"))
-
-        if r.status_code == 401:
-            return phantom.APP_ERROR, r.status_code
-
-        if not 200 <= r.status_code < 300:
-            return RetVal(action_result.set_status(phantom.APP_ERROR, f"Certificate download failed. Status Code: {r.status_code}"))
-
-        if not r.content:
-            return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download is empty"))
-
-        content_disposition = r.headers.get("Content-Disposition", "")
-        file_name = content_disposition.split('"')[1] if '"' in content_disposition else "certificate"
-
-        fd, tmp_file_path = tempfile.mkstemp(dir=Vault.get_vault_tmp_dir())
-        os.close(fd)
-
-        with open(tmp_file_path, "wb") as f:
-            f.write(r.content)
-
-        success, msg, vault_id = ph_rules.vault_add(
-            container=self.get_container_id(),
-            file_location=tmp_file_path,
-            file_name=file_name,
-        )
-
-        if not success:
-            return RetVal(action_result.set_status(phantom.APP_ERROR, f"Error adding file to the vault, Error: {msg}"))
-
-        vault_info = self._get_vault_info(vault_id)
-        if not vault_info:
-            return RetVal(action_result.set_status(phantom.APP_ERROR, f"Failed to find vault entry {vault_id}"))
-
-        action_result.add_data(
-            {phantom.APP_JSON_VAULT_ID: vault_id, phantom.APP_JSON_NAME: file_name, phantom.APP_JSON_SIZE: vault_info["size"]}
-        )
-        self.debug_print("Successfully added file to the vault")
-        return RetVal(action_result.set_status(phantom.APP_SUCCESS))
+        finally:
+            if r is not None:
+                r.close()
+            if tmp_file_path and os.path.exists(tmp_file_path):
+                os.unlink(tmp_file_path)
 
     def _handle_test_connectivity(self, param):
         action_result = self.add_action_result(ActionResult(dict(param)))

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -600,6 +600,10 @@ class VenafiConnector(BaseConnector):
         action_result.add_data(response)
 
         summary = action_result.update_summary({})
+        if not isinstance(response, dict) or response.get("Success") is not True:
+            error = response.get("Error", "The server did not confirm certificate renewal") if isinstance(response, dict) else "Invalid response"
+            summary["status"] = "Failed to renew certificate"
+            return action_result.set_status(phantom.APP_ERROR, f"Failed to renew certificate. Server response: {error}")
         summary["status"] = "Successfully renewed certificate"
 
         return action_result.set_status(phantom.APP_SUCCESS)
@@ -629,6 +633,10 @@ class VenafiConnector(BaseConnector):
         action_result.add_data(response)
 
         summary = action_result.update_summary({})
+        if not isinstance(response, dict) or response.get("Success") is not True:
+            error = response.get("Error", "The server did not confirm certificate revocation") if isinstance(response, dict) else "Invalid response"
+            summary["status"] = "Failed to revoke certificate"
+            return action_result.set_status(phantom.APP_ERROR, f"Failed to revoke certificate. Server response: {error}")
         summary["status"] = "Successfully revoked certificate"
 
         return action_result.set_status(phantom.APP_SUCCESS)

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -438,7 +438,7 @@ class VenafiConnector(BaseConnector):
         # generate api key
         uri = consts.VENAFI_VERIFY_TOKEN_URI
         # make rest call
-        ret_val, response = self._make_rest_call(uri, action_result, params=None, method="get")
+        ret_val, _response = self._make_rest_call(uri, action_result, params=None, method="get")
         if phantom.is_fail(ret_val):
             self.debug_print("Removing old tokens")
             self.remove_tokens()
@@ -634,7 +634,9 @@ class VenafiConnector(BaseConnector):
 
         summary = action_result.update_summary({})
         if not isinstance(response, dict) or response.get("Success") is not True:
-            error = response.get("Error", "The server did not confirm certificate revocation") if isinstance(response, dict) else "Invalid response"
+            error = (
+                response.get("Error", "The server did not confirm certificate revocation") if isinstance(response, dict) else "Invalid response"
+            )
             summary["status"] = "Failed to revoke certificate"
             return action_result.set_status(phantom.APP_ERROR, f"Failed to revoke certificate. Server response: {error}")
         summary["status"] = "Successfully revoked certificate"

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -516,6 +516,10 @@ class VenafiConnector(BaseConnector):
         action_result.add_data(response)
 
         summary = action_result.update_summary({})
+        if not isinstance(response, dict) or response.get("Error") or not response.get("CertificateDN"):
+            error = response.get("Error", "The server did not return a certificate DN") if isinstance(response, dict) else "Invalid response"
+            summary["status"] = "Failed to create certificate"
+            return action_result.set_status(phantom.APP_ERROR, f"Failed to create certificate. Server response: {error}")
         summary["status"] = "Successfully created certificate"
 
         return action_result.set_status(phantom.APP_SUCCESS)

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -394,11 +394,17 @@ class VenafiConnector(BaseConnector):
             error_message = self._get_error_message_from_exception(ex)
             return RetVal(action_result.set_status(phantom.APP_ERROR, f"{error_message}"))
 
-        # If file content length is 0, meaning the file is empty, then fail with the reason
-        if not int(r.headers.get("Content-Length")):
-            return RetVal(action_result.set_status(phantom.APP_ERROR, f"{r.reason}"))
+        if r.status_code == 401:
+            return phantom.APP_ERROR, r.status_code
 
-        file_name = r.headers.get("Content-Disposition", "filename").split('"')[1]
+        if not 200 <= r.status_code < 300:
+            return RetVal(action_result.set_status(phantom.APP_ERROR, f"Certificate download failed. Status Code: {r.status_code}"))
+
+        if not r.content:
+            return RetVal(action_result.set_status(phantom.APP_ERROR, "Certificate download is empty"))
+
+        content_disposition = r.headers.get("Content-Disposition", "")
+        file_name = content_disposition.split('"')[1] if '"' in content_disposition else "certificate"
 
         fd, tmp_file_path = tempfile.mkstemp(dir=Vault.get_vault_tmp_dir())
         os.close(fd)

--- a/venafi_consts.py
+++ b/venafi_consts.py
@@ -42,8 +42,6 @@ VENAFI_ERROR_MESSAGE_UNAVAILABLE = "Error message unavailable. Please check the 
 VENAFI_INVALID_REFRESH_TOKEN = "refresh token is invalid"
 
 VENAFI_DEFAULT_TIMEOUT = 30
-# Match the default SOAR vault-attachment maximum.
-VENAFI_MAX_CERTIFICATE_DOWNLOAD_SIZE = 300 * 1024 * 1024
 VENAFI_DOWNLOAD_CHUNK_SIZE = 64 * 1024
 VENAFI_LIST_CERTIFICATES_PARAMS = {
     "country": "C",

--- a/venafi_consts.py
+++ b/venafi_consts.py
@@ -42,6 +42,9 @@ VENAFI_ERROR_MESSAGE_UNAVAILABLE = "Error message unavailable. Please check the 
 VENAFI_INVALID_REFRESH_TOKEN = "refresh token is invalid"
 
 VENAFI_DEFAULT_TIMEOUT = 30
+# Match the default SOAR vault-attachment maximum.
+VENAFI_MAX_CERTIFICATE_DOWNLOAD_SIZE = 300 * 1024 * 1024
+VENAFI_DOWNLOAD_CHUNK_SIZE = 64 * 1024
 VENAFI_LIST_CERTIFICATES_PARAMS = {
     "country": "C",
     "common_name": "CN",


### PR DESCRIPTION
### Features

- None.

### Bug Fixes

- PSAAS-31742: Treat a Venafi enrollment response without `CertificateDN` or with `Error` as a failed action.
- PSAAS-31914: Reject unsuccessful or empty certificate downloads before adding them to the SOAR vault.
- PSAAS-32446: Require Venafi to confirm renewal and revocation in the response body.
- PSAAS-32043: Exclude certificate-export passwords from the runtime action result while retaining password-typed metadata required by static validation.
- PSAAS-33432: Stream certificate downloads to a temporary file, attempt the SOAR vault write, report vault rejection cleanly, and remove temporary files on every outcome.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate

### Other information

PAPP-38138 under ESPM-5228. The five scoped PSAAS tickets are linked; PSAAS-33432 is being advanced with this PR.

Local validation: focused streamed-vault success/rejection regression harness passed on Python 3.13; Python syntax and diff checks passed. The refreshed v2.2.8 full pre-commit run passed every hook through static tests, then the local Docker engine stopped responding in package-app-dependencies; hosted pre-commit will provide the authoritative containerized gate.

Written by Codex.

## Tracking

- PAPP: PAPP-38138
- PSAAS: PSAAS-31742, PSAAS-34288, PSAAS-34963
- Written by Codex.