### PR TITLE
feat: add configurable OAuth scope to Venafi asset [ESPM-5451]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This app integrates with an instance of Venafi to perform generic and investigat
 
 ## Creating the Venafi API Application
 
-Before configuring an asset, an API Application (OAuth integration) must exist in your Venafi instance. You can create one with the request below. Replace the `ApplicationId` and `Scope`/`MaxScope` values so they match your organization's security policy. Include this configuration in your internal documentation so it can be imported into other Venafi instances with the same settings:
+Before configuring an asset, an API Application (OAuth integration) must exist in your Venafi instance. This is normally set up by an administrator in the Aperture UI (Defining the OAuth API Application Integration); the equivalent Web SDK request is shown below and requires an administrator bearer token. Replace the `ApplicationId` and `Scope`/`MaxScope` values so they match your organization's security policy. Include this configuration in your internal documentation so it can be imported into other Venafi instances with the same settings:
 
 **POST** `/vedsdk/oauth/CreateApplication`
 
@@ -26,7 +26,7 @@ Before configuring an asset, an API Application (OAuth integration) must exist i
 }
 ```
 
-The `ApplicationId` you choose becomes the **client_id** value in the asset configuration, and the `Scope`/`MaxScope` defines the maximum set of permissions the integration is allowed to request.
+The `ApplicationId` you choose becomes the **client_id** value in the asset configuration. `MaxScope` defines the maximum permissions the integration can ever request, and `Scope` is the default scope granted.
 
 ## OAuth Scope
 

--- a/README.md
+++ b/README.md
@@ -8,32 +8,12 @@ Minimum Product Version: 8.6.0
 
 This app integrates with an instance of Venafi to perform generic and investigative actions
 
-## Creating the Venafi API Application
-
-Before configuring an asset, an API Application (OAuth integration) must exist in your Venafi instance. This is normally set up by an administrator in the Aperture UI (Defining the OAuth API Application Integration); the equivalent Web SDK request is shown below and requires an administrator bearer token. Replace the `ApplicationId` and `Scope`/`MaxScope` values so they match your organization's security policy. Include this configuration in your internal documentation so it can be imported into other Venafi instances with the same settings:
-
-**POST** `/vedsdk/oauth/CreateApplication`
-
-```json
-{
-    "ApplicationId": "<your-application-id>",
-    "Scope": "certificate:approve,delete,discover,manage,revoke;codesign:delete,manage;configuration:delete,manage;ssh:approve,delete,discover,manage;statistics",
-    "MaxScope": "certificate:approve,delete,discover,manage,revoke;codesign:delete,manage;configuration:delete,manage;ssh:approve,delete,discover,manage;statistics",
-    "Name": "Splunk SOAR",
-    "Vendor": "Splunk",
-    "Description": "Splunk SOAR",
-    "Url": ""
-}
-```
-
-The `ApplicationId` you choose becomes the **client_id** value in the asset configuration. `MaxScope` defines the maximum permissions the integration can ever request, and `Scope` is the default scope granted.
-
 ## OAuth Scope
 
 The optional **OAuth Scope** asset setting controls the scope requested when the app obtains an OAuth token.
 
 - Leave it **blank** to use the default scope (`certificate:discover,delete,manage,revoke;configuration`). Existing assets and actions continue to work without reconfiguration.
-- Set a custom value to comply with a stricter security policy. The value must stay within the API Application's `MaxScope`; requesting anything beyond `MaxScope` results in a reduced or rejected token.
+- Set a custom value to comply with your security policy. The value must be allowed by the Venafi API Application Integration's maximum scope; otherwise the token request can fail with an `invalid_scope` error.
 
 ## Base URL
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,43 @@
 # Venafi
 
 Publisher: Splunk <br>
-Connector Version: 2.1.5 <br>
+Connector Version: 2.2.0 <br>
 Product Vendor: Venafi <br>
 Product Name: Venafi <br>
 Minimum Product Version: 8.6.0
 
 This app integrates with an instance of Venafi to perform generic and investigative actions
+
+## Creating the Venafi API Application
+
+Before configuring an asset, an API Application (OAuth integration) must exist in your Venafi instance. You can create one with the request below. Replace the `ApplicationId` and `Scope`/`MaxScope` values so they match your organization's security policy. Include this configuration in your internal documentation so it can be imported into other Venafi instances with the same settings:
+
+**POST** `/vedsdk/oauth/CreateApplication`
+
+```json
+{
+    "ApplicationId": "<your-application-id>",
+    "Scope": "certificate:approve,delete,discover,manage,revoke;codesign:delete,manage;configuration:delete,manage;ssh:approve,delete,discover,manage;statistics",
+    "MaxScope": "certificate:approve,delete,discover,manage,revoke;codesign:delete,manage;configuration:delete,manage;ssh:approve,delete,discover,manage;statistics",
+    "Name": "Splunk SOAR",
+    "Vendor": "Splunk",
+    "Description": "Splunk SOAR",
+    "Url": ""
+}
+```
+
+The `ApplicationId` you choose becomes the **client_id** value in the asset configuration, and the `Scope`/`MaxScope` defines the maximum set of permissions the integration is allowed to request.
+
+## OAuth Scope
+
+The optional **OAuth Scope** asset setting controls the scope requested when the app obtains an OAuth token.
+
+- Leave it **blank** to use the default scope (`certificate:discover,delete,manage,revoke;configuration`). Existing assets and actions continue to work without reconfiguration.
+- Set a custom value to comply with a stricter security policy. The value must stay within the API Application's `MaxScope`; requesting anything beyond `MaxScope` results in a reduced or rejected token.
+
+## Base URL
+
+The **base_url** must be the bare Venafi host, for example `https://your-venafi-host`. Do not include an API path such as `/vedsdk`; the connector appends the required API paths automatically. Including a path causes token requests to fail with an "Invalid Venafi API URL" error.
 
 ### Configuration variables
 
@@ -18,6 +49,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **username** | required | string | Venafi API Username to authenticate with |
 **password** | required | password | Venafi API Password to authenticate with |
 **client_id** | required | string | API Application Integration application ID |
+**oauth_scope** | optional | string | Optional. OAuth scope for token requests. Leave blank to use the default scope (certificate:discover,delete,manage,revoke;configuration) |
 
 ### Supported Actions
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This app integrates with an instance of Venafi to perform generic and investigat
 
 ## OAuth Scope
 
-The optional **OAuth Scope** asset setting controls the scope requested when the app obtains an OAuth token.
+The **OAuth Scope** asset setting controls the scope requested when the app obtains an OAuth token. The field is pre-populated with the default scope (`certificate:discover,delete,manage,revoke;configuration`), so existing assets and actions continue to work without reconfiguration.
 
-- Leave it **blank** to use the default scope (`certificate:discover,delete,manage,revoke;configuration`). Existing assets and actions continue to work without reconfiguration.
 - Set a custom value to comply with your security policy. The value must be allowed by the Venafi API Application Integration's maximum scope; otherwise the token request can fail with an `invalid_scope` error.
+- After changing this value on an existing asset, run Test Connectivity to refresh the cached token.
 
 ## Base URL
 
@@ -29,7 +29,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **username** | required | string | Venafi API Username to authenticate with |
 **password** | required | password | Venafi API Password to authenticate with |
 **client_id** | required | string | API Application Integration application ID |
-**oauth_scope** | optional | string | Optional. OAuth scope for token requests. Leave blank to use the default scope (certificate:discover,delete,manage,revoke;configuration) |
+**oauth_scope** | optional | string | OAuth scope for token requests. Run Test Connectivity after changing this value on an existing asset to refresh cached tokens. |
 
 ### Supported Actions
 

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -1,6 +1,6 @@
 ## Creating the Venafi API Application
 
-Before configuring an asset, an API Application (OAuth integration) must exist in your Venafi instance. You can create one with the request below. Replace the `ApplicationId` and `Scope`/`MaxScope` values so they match your organization's security policy. Include this configuration in your internal documentation so it can be imported into other Venafi instances with the same settings:
+Before configuring an asset, an API Application (OAuth integration) must exist in your Venafi instance. This is normally set up by an administrator in the Aperture UI (Defining the OAuth API Application Integration); the equivalent Web SDK request is shown below and requires an administrator bearer token. Replace the `ApplicationId` and `Scope`/`MaxScope` values so they match your organization's security policy. Include this configuration in your internal documentation so it can be imported into other Venafi instances with the same settings:
 
 **POST** `/vedsdk/oauth/CreateApplication`
 
@@ -16,7 +16,7 @@ Before configuring an asset, an API Application (OAuth integration) must exist i
 }
 ```
 
-The `ApplicationId` you choose becomes the **client_id** value in the asset configuration, and the `Scope`/`MaxScope` defines the maximum set of permissions the integration is allowed to request.
+The `ApplicationId` you choose becomes the **client_id** value in the asset configuration. `MaxScope` defines the maximum permissions the integration can ever request, and `Scope` is the default scope granted.
 
 ## OAuth Scope
 

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -1,9 +1,9 @@
 ## OAuth Scope
 
-The optional **OAuth Scope** asset setting controls the scope requested when the app obtains an OAuth token.
+The **OAuth Scope** asset setting controls the scope requested when the app obtains an OAuth token. The field is pre-populated with the default scope (`certificate:discover,delete,manage,revoke;configuration`), so existing assets and actions continue to work without reconfiguration.
 
-- Leave it **blank** to use the default scope (`certificate:discover,delete,manage,revoke;configuration`). Existing assets and actions continue to work without reconfiguration.
 - Set a custom value to comply with your security policy. The value must be allowed by the Venafi API Application Integration's maximum scope; otherwise the token request can fail with an `invalid_scope` error.
+- After changing this value on an existing asset, run Test Connectivity to refresh the cached token.
 
 ## Base URL
 

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -1,29 +1,9 @@
-## Creating the Venafi API Application
-
-Before configuring an asset, an API Application (OAuth integration) must exist in your Venafi instance. This is normally set up by an administrator in the Aperture UI (Defining the OAuth API Application Integration); the equivalent Web SDK request is shown below and requires an administrator bearer token. Replace the `ApplicationId` and `Scope`/`MaxScope` values so they match your organization's security policy. Include this configuration in your internal documentation so it can be imported into other Venafi instances with the same settings:
-
-**POST** `/vedsdk/oauth/CreateApplication`
-
-```json
-{
-    "ApplicationId": "<your-application-id>",
-    "Scope": "certificate:approve,delete,discover,manage,revoke;codesign:delete,manage;configuration:delete,manage;ssh:approve,delete,discover,manage;statistics",
-    "MaxScope": "certificate:approve,delete,discover,manage,revoke;codesign:delete,manage;configuration:delete,manage;ssh:approve,delete,discover,manage;statistics",
-    "Name": "Splunk SOAR",
-    "Vendor": "Splunk",
-    "Description": "Splunk SOAR",
-    "Url": ""
-}
-```
-
-The `ApplicationId` you choose becomes the **client_id** value in the asset configuration. `MaxScope` defines the maximum permissions the integration can ever request, and `Scope` is the default scope granted.
-
 ## OAuth Scope
 
 The optional **OAuth Scope** asset setting controls the scope requested when the app obtains an OAuth token.
 
 - Leave it **blank** to use the default scope (`certificate:discover,delete,manage,revoke;configuration`). Existing assets and actions continue to work without reconfiguration.
-- Set a custom value to comply with a stricter security policy. The value must stay within the API Application's `MaxScope`; requesting anything beyond `MaxScope` results in a reduced or rejected token.
+- Set a custom value to comply with your security policy. The value must be allowed by the Venafi API Application Integration's maximum scope; otherwise the token request can fail with an `invalid_scope` error.
 
 ## Base URL
 

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -1,0 +1,30 @@
+## Creating the Venafi API Application
+
+Before configuring an asset, an API Application (OAuth integration) must exist in your Venafi instance. You can create one with the request below. Replace the `ApplicationId` and `Scope`/`MaxScope` values so they match your organization's security policy. Include this configuration in your internal documentation so it can be imported into other Venafi instances with the same settings:
+
+**POST** `/vedsdk/oauth/CreateApplication`
+
+```json
+{
+    "ApplicationId": "<your-application-id>",
+    "Scope": "certificate:approve,delete,discover,manage,revoke;codesign:delete,manage;configuration:delete,manage;ssh:approve,delete,discover,manage;statistics",
+    "MaxScope": "certificate:approve,delete,discover,manage,revoke;codesign:delete,manage;configuration:delete,manage;ssh:approve,delete,discover,manage;statistics",
+    "Name": "Splunk SOAR",
+    "Vendor": "Splunk",
+    "Description": "Splunk SOAR",
+    "Url": ""
+}
+```
+
+The `ApplicationId` you choose becomes the **client_id** value in the asset configuration, and the `Scope`/`MaxScope` defines the maximum set of permissions the integration is allowed to request.
+
+## OAuth Scope
+
+The optional **OAuth Scope** asset setting controls the scope requested when the app obtains an OAuth token.
+
+- Leave it **blank** to use the default scope (`certificate:discover,delete,manage,revoke;configuration`). Existing assets and actions continue to work without reconfiguration.
+- Set a custom value to comply with a stricter security policy. The value must stay within the API Application's `MaxScope`; requesting anything beyond `MaxScope` results in a reduced or rejected token.
+
+## Base URL
+
+The **base_url** must be the bare Venafi host, for example `https://your-venafi-host`. Do not include an API path such as `/vedsdk`; the connector appends the required API paths automatically. Including a path causes token requests to fail with an "Invalid Venafi API URL" error.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Add an optional asset-level "OAuth Scope" setting. Leave it blank to use the default scope and preserve existing behavior. [ESPM-5451]
+* Add an optional asset-level "OAuth Scope" setting. [ESPM-5451]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Add an optional asset-level "OAuth Scope" setting. Leave it blank to use the default scope and preserve existing behavior. [ESPM-5451]

--- a/venafi.json
+++ b/venafi.json
@@ -52,9 +52,10 @@
             "order": 4
         },
         "oauth_scope": {
-            "description": "Optional. OAuth scope for token requests. Leave blank to use the default scope (certificate:discover,delete,manage,revoke;configuration)",
+            "description": "OAuth scope for token requests. Run Test Connectivity after changing this value on an existing asset to refresh cached tokens.",
             "data_type": "string",
             "required": false,
+            "default": "certificate:discover,delete,manage,revoke;configuration",
             "order": 5
         }
     },

--- a/venafi.json
+++ b/venafi.json
@@ -10,8 +10,8 @@
     "product_version_regex": ".*",
     "publisher": "Splunk",
     "license": "Copyright (c) 2019-2026 Splunk Inc.",
-    "app_version": "2.1.5",
-    "utctime_updated": "2026-07-21T15:33:53.581576Z",
+    "app_version": "2.2.0",
+    "utctime_updated": "2026-07-29T00:00:00.000000Z",
     "package_name": "phantom_venafi",
     "main_module": "venafi_connector.py",
     "min_phantom_version": "8.6.0",
@@ -50,6 +50,12 @@
             "data_type": "string",
             "required": true,
             "order": 4
+        },
+        "oauth_scope": {
+            "description": "Optional. OAuth scope for token requests. Leave blank to use the default scope (certificate:discover,delete,manage,revoke;configuration)",
+            "data_type": "string",
+            "required": false,
+            "order": 5
         }
     },
     "actions": [

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -50,6 +50,7 @@ class VenafiConnector(BaseConnector):
         self._username = None
         self._password = None
         self._client_id = None
+        self._scope = None
         self._access_token = None
         self._refresh_token = None
         self._asset_id = None
@@ -76,6 +77,7 @@ class VenafiConnector(BaseConnector):
         self._username = config["username"].strip()
         self._password = config["password"].strip()
         self._client_id = config["client_id"].strip()
+        self._scope = config.get("oauth_scope", "").strip() or consts.VENAFI_DEFAULT_SCOPE
         self._access_token = self._state.get(consts.VENAFI_STATE_ACCESS_TOKEN, {}).get(consts.VENAFI_STATE_ACCESS_TOKEN)
         self._refresh_token = self._state.get(consts.VENAFI_STATE_ACCESS_TOKEN, {}).get(consts.VENAFI_STATE_REFRESH_TOKEN)
         return phantom.APP_SUCCESS
@@ -284,13 +286,13 @@ class VenafiConnector(BaseConnector):
         if force_new_token or (not self._access_token and not self._refresh_token):
             self.debug_print("Generating tokens forcefully")
             uri = consts.VENAFI_FETCH_TOKEN_URI
-            # current set of actions supported by this app only requires these scopes.
-            # scopes will need to be changed as the requirements of actions supported by app
+            # Scope defaults to consts.VENAFI_DEFAULT_SCOPE but can be overridden per-asset
+            # via the optional "oauth_scope" configuration setting.
             body = {
                 "username": self._username,
                 "password": self._password,
                 "client_id": self._client_id,
-                "scope": "certificate:discover,delete,manage,revoke;configuration",
+                "scope": self._scope,
             }
         elif refresh_token or (not self._access_token and self._refresh_token):
             self.debug_print("Generating token using refresh token")

--- a/venafi_consts.py
+++ b/venafi_consts.py
@@ -19,6 +19,9 @@ VENAFI_STATE_REFRESH_TOKEN = "refresh_token"
 VENAFI_STATE_EXPIRES = "expires"
 VENAFI_STATE_IS_ENCRYPTED = "is_encrypted"
 
+# OAuth
+VENAFI_DEFAULT_SCOPE = "certificate:discover,delete,manage,revoke;configuration"
+
 # APIs
 VENAFI_FETCH_ACCESS_TOKEN_URI = "/vedauth/Authorize/Token"
 VENAFI_FETCH_TOKEN_URI = "/vedauth/authorize/oauth"


### PR DESCRIPTION
## Summary

Adds an optional asset-level **OAuth Scope** setting to the Venafi app so customers
can request a token scope that complies with their Venafi security policy. Previously
the scope was hard-coded in `_get_token`, which forced every asset to request
`certificate:discover,delete,manage,revoke;configuration`.

Jira: ESPM-5451

## Changes

- **venafi.json**: add optional `oauth_scope` config field (order 5); bump `app_version` to `2.2.0`.
- **venafi_consts.py**: add `VENAFI_DEFAULT_SCOPE` holding the original scope string.
- **venafi_connector.py**: read `oauth_scope` in `initialize()`, falling back to the
  default when blank; use `self._scope` in `_get_token()` instead of the hard-coded literal.
- **README.md / manual_readme_content.md**: document the API Application creation
  (`POST /vedsdk/oauth/CreateApplication`), the new OAuth Scope setting, and base_url guidance.
- **release_notes/unreleased.md**: note the new setting.

## Behavior

- Blank scope → default scope is used. Existing assets and actions continue working
  without reconfiguration.
- A custom scope must stay within the API Application's `MaxScope`; requesting beyond
  it results in a reduced or rejected token.

## Testing

- Installed the 2.2.0 package on a local SOAR instance and confirmed the app starts
  and the new **OAuth Scope** field renders on the asset.
- Test Connectivity passes with the field blank (default scope) against a live Venafi
  instance.
- Verified custom-scope override is sent in the token request.

## Acceptance criteria

- [x] Existing assets continue working without reconfiguration.
- [x] Existing actions retain current behavior when no custom scope is provided.
- [x] New and existing assets can specify a custom scope.