### PR TITLE
fix: harden Venafi response handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.42.1
+    rev: v1.43.2
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.8
+    rev: v2.2.9
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -351,8 +351,6 @@ action_result.summary.status | string | | Successfully retrieved certificate and
 action_result.message | string | | Status: Successfully retrieved certificate and downloaded it to vault |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.keystore_password | password | | |
-action_result.parameter.password | password | | |
 
 ______________________________________________________________________
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Handles non-object JSON error responses without an unhandled exception.
 * Validates Venafi OAuth responses before storing access and refresh tokens.
 * Discards stored Venafi tokens when the configured TPP base URL changes.
+* Handles unexpected Venafi list response shapes as action errors.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Handles non-object JSON error responses without an unhandled exception.
+* Validates Venafi OAuth responses before storing access and refresh tokens.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Handles non-object JSON error responses without an unhandled exception.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Handles non-object JSON error responses without an unhandled exception.
 * Validates Venafi OAuth responses before storing access and refresh tokens.
+* Discards stored Venafi tokens when the configured TPP base URL changes.

--- a/venafi.json
+++ b/venafi.json
@@ -1512,14 +1512,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.keystore_password",
-                    "data_type": "password"
-                },
-                {
-                    "data_path": "action_result.parameter.password",
-                    "data_type": "password"
                 }
             ],
             "render": {

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -80,6 +80,11 @@ class VenafiConnector(BaseConnector):
         self._scope = config.get("oauth_scope", "").strip() or consts.VENAFI_DEFAULT_SCOPE
         self._access_token = self._state.get(consts.VENAFI_STATE_ACCESS_TOKEN, {}).get(consts.VENAFI_STATE_ACCESS_TOKEN)
         self._refresh_token = self._state.get(consts.VENAFI_STATE_ACCESS_TOKEN, {}).get(consts.VENAFI_STATE_REFRESH_TOKEN)
+        if (self._access_token or self._refresh_token) and self._state.get(consts.VENAFI_STATE_TOKEN_BASE_URL) != self._base_url:
+            self.debug_print("Asset base URL changed since the stored tokens were issued; discarding stored tokens")
+            self._access_token = None
+            self._refresh_token = None
+            self.remove_tokens()
         return phantom.APP_SUCCESS
 
     def encrypt_state(self):
@@ -127,8 +132,14 @@ class VenafiConnector(BaseConnector):
         self._state[consts.VENAFI_STATE_IS_ENCRYPTED] = False
 
     def remove_tokens(self):
+        state_changed = False
         if self._state.get(consts.VENAFI_STATE_ACCESS_TOKEN):
             self._state.pop(consts.VENAFI_STATE_ACCESS_TOKEN)
+            state_changed = True
+        if self._state.get(consts.VENAFI_STATE_TOKEN_BASE_URL):
+            self._state.pop(consts.VENAFI_STATE_TOKEN_BASE_URL)
+            state_changed = True
+        if state_changed:
             self.save_state(self._state)
 
     @staticmethod
@@ -339,6 +350,7 @@ class VenafiConnector(BaseConnector):
             )
 
         self.save_progress("Successfully generated Access Token")
+        self._state[consts.VENAFI_STATE_TOKEN_BASE_URL] = self._base_url
         self._state[consts.VENAFI_STATE_ACCESS_TOKEN] = resp_json
         self._access_token = resp_json[consts.VENAFI_STATE_ACCESS_TOKEN]
         self._refresh_token = resp_json.get(consts.VENAFI_STATE_REFRESH_TOKEN)

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -239,7 +239,7 @@ class VenafiConnector(BaseConnector):
         if 200 <= r.status_code < 399:
             return RetVal(phantom.APP_SUCCESS, resp_json)
 
-        if "error_description" in resp_json and "error" in resp_json:
+        if isinstance(resp_json, dict) and "error_description" in resp_json and "error" in resp_json:
             message = resp_json["error_description"]
         # You should process the error returned in the json
         else:

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -322,11 +322,26 @@ class VenafiConnector(BaseConnector):
             else:
                 return self._process_response(response, action_result)
 
-        resp_json = response.json()
+        try:
+            resp_json = response.json()
+        except Exception as ex:
+            error_message = self._get_error_message_from_exception(ex)
+            return RetVal(
+                action_result.set_status(phantom.APP_ERROR, f"Unable to parse JSON response from token endpoint. {error_message}"), None
+            )
+
+        if not isinstance(resp_json, dict) or not resp_json.get(consts.VENAFI_STATE_ACCESS_TOKEN):
+            return RetVal(
+                action_result.set_status(
+                    phantom.APP_ERROR, "Unexpected response from token endpoint: expected a JSON object containing an access token"
+                ),
+                None,
+            )
+
         self.save_progress("Successfully generated Access Token")
         self._state[consts.VENAFI_STATE_ACCESS_TOKEN] = resp_json
         self._access_token = resp_json[consts.VENAFI_STATE_ACCESS_TOKEN]
-        self._refresh_token = resp_json[consts.VENAFI_STATE_REFRESH_TOKEN]
+        self._refresh_token = resp_json.get(consts.VENAFI_STATE_REFRESH_TOKEN)
         self.encrypt_state()
         self.save_state(self._state)
         return RetVal(phantom.APP_SUCCESS, None)

--- a/venafi_connector.py
+++ b/venafi_connector.py
@@ -583,11 +583,16 @@ class VenafiConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             return ret_val
 
-        for policy in response["Objects"]:
+        objects = response.get("Objects") if isinstance(response, dict) else None
+        if not isinstance(objects, list):
+            error = response.get("Error", "The server did not return an Objects list") if isinstance(response, dict) else "Invalid response"
+            return action_result.set_status(phantom.APP_ERROR, f"Failed to list policies. Server response: {error}")
+
+        for policy in objects:
             action_result.add_data(policy)
 
         summary = action_result.update_summary({})
-        summary["num_policies"] = len(response["Objects"])
+        summary["num_policies"] = len(objects)
 
         return action_result.set_status(phantom.APP_SUCCESS)
 
@@ -616,11 +621,16 @@ class VenafiConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             return ret_val
 
-        for certificate in response["Certificates"]:
+        certificates = response.get("Certificates") if isinstance(response, dict) else None
+        if not isinstance(certificates, list):
+            error = response.get("Error", "The server did not return a Certificates list") if isinstance(response, dict) else "Invalid response"
+            return action_result.set_status(phantom.APP_ERROR, f"Failed to list certificates. Server response: {error}")
+
+        for certificate in certificates:
             action_result.add_data(certificate)
 
         summary = action_result.update_summary({})
-        summary["num_certificates"] = len(response["Certificates"])
+        summary["num_certificates"] = len(certificates)
 
         return action_result.set_status(phantom.APP_SUCCESS)
 

--- a/venafi_consts.py
+++ b/venafi_consts.py
@@ -18,6 +18,7 @@ VENAFI_STATE_ACCESS_TOKEN = "access_token"
 VENAFI_STATE_REFRESH_TOKEN = "refresh_token"
 VENAFI_STATE_EXPIRES = "expires"
 VENAFI_STATE_IS_ENCRYPTED = "is_encrypted"
+VENAFI_STATE_TOKEN_BASE_URL = "token_base_url"
 
 # OAuth
 VENAFI_DEFAULT_SCOPE = "certificate:discover,delete,manage,revoke;configuration"


### PR DESCRIPTION
### Features

- None.

### Bug Fixes

- PSAAS-34221: Handle non-object JSON error responses without an unhandled exception.
- PSAAS-34287: Validate OAuth success responses while allowing the documented access-token-only grant shape.
- PSAAS-34399: Bind stored access and refresh tokens to the configured Venafi TPP base URL.
- PSAAS-34637: Validate the documented Objects and Certificates arrays before list actions consume them.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate

### Other information

PAPP-38138 under ESPM-5228. Primary provenance: PSAAS-34221 (VULN-101745, FS-7729), PSAAS-34287 (VULN-101811, FS-7795), PSAAS-34399 (VULN-101922, FS-7906), and PSAAS-34637 (VULN-102161, FS-8144). PSAAS-34288 (VULN-101812, FS-7796) and PSAAS-34963 (VULN-103584, FS-8517) were excluded because merged PR #26 already fixed their reported revoke-confirmation and download-header crashes on current `main`. No active refreshed finding required a TLS-verification, platform, or vault change. Jira labels were not changed.

Official Venafi sources: [Authorize/OAuth](https://docs.venafi.com/Docs/25.1/TopNav/Content/SDK/AuthSDK/r-SDKa-POST-AuthorizeOAuth.php), [Authorize/Token refresh](https://docs.venafi.com/Docs/25.3/TopNav/Content/SDK/AuthSDK/r-SDKa-POST-AuthorizeToken.php), [Config/FindObjectsOfClass](https://docs.venafi.com/Docs/25.3/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-findobjectsofclass.php), [GET Certificates](https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-GET-Certificates.php), [Certificates/Revoke](https://docs.venafi.com/Docs/currentSDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-revoke.php), and [GET Certificates/Retrieve](https://docs.venafi.com/Docs/25.3/TopNav/Content/SDK/WebSDK/r-SDK-GET-Certificates-retrieve.php). The OAuth implementation is intentionally narrower than the supplied patch because Venafi documents `refresh_token` as optional for the initial OAuth grant; this PR requires `access_token` and stores a refresh token only when supplied.

Checks: recorded connector preflight passed for ESPM-5228 / Certified Apps; `pre-commit run --all-files` passed every hook, including Docker-backed dependency packaging and static tests; `/opt/homebrew/bin/python3.13 -m py_compile venafi_connector.py venafi_consts.py` passed; `git diff --check origin/main..HEAD` passed. This is a BaseConnector app, so no connector-local unit-test harness was added. Integration and sanity tests are deferred under campaign policy.

Breaking changes: none.

Merge strategy: merge commit only; do not squash

Written by Codex.